### PR TITLE
fix: Fixed bluetooth manual disconnection when bluetooth is back in the second

### DIFF
--- a/blessed/src/main/java/com/welie/blessed/BluetoothCentralManager.kt
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothCentralManager.kt
@@ -860,8 +860,12 @@ class BluetoothCentralManager(private val context: Context) {
     private fun startDisconnectionTimer() {
         cancelDisconnectionTimer()
         disconnectRunnable = Runnable {
-            Logger.e(TAG, "bluetooth turned off but no automatic disconnects happening, so doing it ourselves")
-            cancelAllConnectionsWhenBluetoothOff()
+            if (expectingBluetoothOffDisconnects) {
+                Logger.e(TAG, "bluetooth turned off but no automatic disconnects happening, so doing it ourselves")
+                cancelAllConnectionsWhenBluetoothOff()
+            } else {
+                Logger.e(TAG, "bluetooth turning on since manual disconnection timer has been launched, don't disconnect")
+            }
             disconnectRunnable = null
         }
         mainHandler.postDelayed(disconnectRunnable!!, 1000)


### PR DESCRIPTION
Fix this : 
```
05-25 18:28:58:019 D/BluetoothCentralManager(2) : bluetooth turning off
05-25 18:28:58:029 W/BluetoothPeripheral(1533) : cannot cancel connection because no connection attempt is made yet
05-25 18:28:58:389 D/BluetoothCentralManager(2) : bluetooth turned off
05-25 18:28:58:823 D/BluetoothCentralManager(2) : bluetooth turning on
05-25 18:28:59:121 D/BluetoothCentralManager(2) : bluetooth turned on
05-25 18:28:59:390 E/BluetoothCentralManager(2) : bluetooth turned off but no automatic disconnects happening, so doing it ourselves
05-25 18:28:59:391 D/BluetoothCentralManager(2) : disconnect all peripherals because bluetooth is off
```