### PR TITLE
BluetoothGatt null protection in startConnectionTimer

### DIFF
--- a/blessed/src/main/java/com/welie/blessed/BluetoothPeripheral.kt
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothPeripheral.kt
@@ -1515,7 +1515,9 @@ class BluetoothPeripheral internal constructor(
             disconnect()
             scope.launch {
                 delay(50)
-                bluetoothGattCallback.onConnectionStateChange(bluetoothGatt, HciStatus.CONNECTION_FAILED_ESTABLISHMENT.value, BluetoothProfile.STATE_DISCONNECTED)
+                if (bluetoothGatt != null) {
+                    bluetoothGattCallback.onConnectionStateChange(bluetoothGatt, HciStatus.CONNECTION_FAILED_ESTABLISHMENT.value, BluetoothProfile.STATE_DISCONNECTED)
+                }            
             }
         }
     }


### PR DESCRIPTION
Added protection in startConnectionTimer for potential null bluetoothGatt when calling onConnectionStateChange callback.

Same change as in v2.2.3 of the blessed-android repository, ported as is.